### PR TITLE
Fix compilation with GHC 8.6

### DIFF
--- a/broadcast-chan-pipes/broadcast-chan-pipes.cabal
+++ b/broadcast-chan-pipes/broadcast-chan-pipes.cabal
@@ -52,7 +52,7 @@ Test-Suite pipes
                ,        containers >= 0.4 && < 0.6
                ,        foldl >= 1.0.4 && < 1.5
                ,        pipes >= 4.1.6 && < 4.4
-               ,        pipes-safe == 2.2 && < 2.4
+               ,        pipes-safe >= 2.2 && < 2.4
 
 Source-Repository head
   Type:     git

--- a/broadcast-chan-pipes/broadcast-chan-pipes.cabal
+++ b/broadcast-chan-pipes/broadcast-chan-pipes.cabal
@@ -38,7 +38,7 @@ Library
   Build-Depends:        base >= 4.7 && < 5
                ,        broadcast-chan == 0.2.0.*
                ,        pipes >= 4.1.6 && < 4.4
-               ,        pipes-safe == 2.2.*
+               ,        pipes-safe >= 2.2 && < 2.4
 
 Test-Suite pipes
   Default-Language:     Haskell2010

--- a/broadcast-chan-pipes/broadcast-chan-pipes.cabal
+++ b/broadcast-chan-pipes/broadcast-chan-pipes.cabal
@@ -52,7 +52,7 @@ Test-Suite pipes
                ,        containers >= 0.4 && < 0.6
                ,        foldl >= 1.0.4 && < 1.5
                ,        pipes >= 4.1.6 && < 4.4
-               ,        pipes-safe == 2.2.*
+               ,        pipes-safe == 2.2 && < 2.4
 
 Source-Repository head
   Type:     git

--- a/broadcast-chan/BroadcastChan/Extra.hs
+++ b/broadcast-chan/BroadcastChan/Extra.hs
@@ -231,8 +231,8 @@ runParallel yielder hndl threads work pipe = do
 
     let queueAndYield :: a -> m (Maybe b)
         queueAndYield x = do
-            Just v <- liftIO $ readBChan outChanOut <* bufferValue x
-            return v
+            mV <- liftIO $ readBChan outChanOut <* bufferValue x
+            maybe (error "runParallel: readBChan failed") pure mV
 
         finish :: r -> n r
         finish r = do

--- a/broadcast-chan/BroadcastChan/Extra.hs
+++ b/broadcast-chan/BroadcastChan/Extra.hs
@@ -232,7 +232,7 @@ runParallel yielder hndl threads work pipe = do
     let queueAndYield :: a -> m (Maybe b)
         queueAndYield x = do
             mV <- liftIO $ readBChan outChanOut <* bufferValue x
-            maybe (error "runParallel: readBChan failed") pure mV
+            maybe (error "runParallel: readBChan failed") return mV
 
         finish :: r -> n r
         finish r = do


### PR DESCRIPTION
A refutable pattern match in the `runParallel` function in
`BroadcastChan/Extra.hs` prevents it from compiling under the new
`MonadFail` regime.

This commit makes the pattern match failure explicit using `error` which
should work on older GHCs and won't cascade `MonadFail` constraints
elsewhere.

The bounds of pipes-safe also needed extending.